### PR TITLE
Fix dark mode toggle to apply globally

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,24 +1,14 @@
 @import "tailwindcss";
 
-:root {
-  --background: #0a0a0a;
-  --foreground: #ededed;
-}
-
-html.light {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+@layer base {
+  body {
+    @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors;
+    font-family: Arial, Helvetica, sans-serif;
+  }
 }
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,9 +24,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="h-full dark">
+    <html lang="en" className="h-full">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased h-full bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased h-full transition-colors`}
       >
         <ThemeToggle />
         <div className="min-h-full">

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -3,26 +3,20 @@
 import { useEffect, useState } from 'react';
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
 
-  // Load stored theme on mount
+  // Load stored or system theme on mount
   useEffect(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('theme') : null;
-    if (stored === 'light' || stored === 'dark') {
-      setTheme(stored);
-    }
+    const stored = typeof window !== 'undefined' ? (localStorage.getItem('theme') as 'light' | 'dark' | null) : null;
+    const prefersDark = typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored ?? (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    document.documentElement.classList.toggle('dark', initial === 'dark');
   }, []);
 
   // Apply theme class to html element and persist to storage
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-      root.classList.remove('light');
-    } else {
-      root.classList.remove('dark');
-      root.classList.add('light');
-    }
+    document.documentElement.classList.toggle('dark', theme === 'dark');
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -25,13 +25,18 @@ export interface UseTimerReturn {
 export function useTimer(): UseTimerReturn {
   const [timers, setTimers] = useState<Timer[]>([]);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioRef = useRef<{ play: () => void } | null>(null);
 
   // Initialize audio for timer completion
   useEffect(() => {
     // Create a simple beep sound using Web Audio API
     const createBeepSound = () => {
-      const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+      type WebkitAudioContext = {
+        webkitAudioContext: typeof AudioContext;
+      };
+      const AudioContextConstructor =
+        window.AudioContext || (window as unknown as WebkitAudioContext).webkitAudioContext;
+      const audioContext = new AudioContextConstructor();
       const oscillator = audioContext.createOscillator();
       const gainNode = audioContext.createGain();
       
@@ -49,7 +54,7 @@ export function useTimer(): UseTimerReturn {
       oscillator.stop(audioContext.currentTime + 0.5);
     };
 
-    audioRef.current = { play: createBeepSound } as any;
+    audioRef.current = { play: createBeepSound };
   }, []);
 
   // Timer update loop

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,3 +1,5 @@
+import type { ParsedRecipe } from '@/types/api';
+
 /**
  * LRU Cache with TTL (Time To Live) support
  * Used for caching parsed recipe data with 24-hour expiration
@@ -142,4 +144,4 @@ export class LRUCache<T> {
 }
 
 // Global cache instance for recipe parsing
-export const recipeCache = new LRUCache<any>(100, 24 * 60 * 60 * 1000); // 100 entries, 24h TTL
+export const recipeCache = new LRUCache<ParsedRecipe>(100, 24 * 60 * 60 * 1000); // 100 entries, 24h TTL

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -217,7 +217,7 @@ export function cleanUrl(url: string, baseUrl?: string): string | null {
 /**
  * Debounce function for rate limiting
  */
-export function debounce<T extends (...args: any[]) => any>(
+export function debounce<T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {


### PR DESCRIPTION
## Summary
- remove hardcoded `dark` class from html and simplify layout styles
- rework theme toggle to load system/local preference and toggle `dark` class
- centralize body styling in globals.css for consistent dark mode
- replace lingering `any` types with explicit typings to satisfy lint rules

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b618b1107c832ead37eb3523dc27d2